### PR TITLE
ASM-4009 Dell IOM Untag configuration is skipped when there is change in Tagged VLANs but untag vlan is same

### DIFF
--- a/lib/puppet/util/network_device/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet/util/network_device/dell_iom/model/ioa_interface/base.rb
@@ -120,7 +120,10 @@ module Puppet::Util::NetworkDevice::Dell_iom::Model::Ioa_interface::Base
           end
         end
 
-        transport.command("no vlan untagged")
+        # Untag VLAN needs to be updated only if there is a overlap of untag VLAN with existing list of tag vlans
+        untag_vlan = ( existing_config.scan(/vlan untagged\s+(.*?)$/m).flatten.first || '' )
+        transport.command("no vlan untagged") if temp_vlans.include?(untag_vlan)
+
         transport.command("no vlan tagged #{missing_vlans}") if !missing_vlans.nil?
         transport.command("vlan tagged #{vlans_toadd}") if !vlans_toadd.nil?
       end


### PR DESCRIPTION
Added validation before executing command "no vlan untagged" while configuring tag VLAN configuration. This command will be executed only when Tagged VLAN list include the list of tagged VLANs