### PR TITLE
ASM-5512 FCoE VLAN is getting removed during untagging on PXE VLAN and on retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 script: "bundle exec rake"
 rvm:
   - 1.9.3

--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -128,9 +128,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
         transport.command("vlan tagged #{vlans_toadd}") if !vlans_toadd.nil?
       end
 
-      remove do |transport, old_value|
-        transport.command("no vlan tagged #{old_value}")
-      end
+      remove { |*_| }
     end
 
     ifprop(base, :vlan_untagged) do


### PR DESCRIPTION
While adding / adding new vlans to IOA interface all the existing VLANs are getting removed first. This has few issues
- Network traffic coming out of server facing port will be disturbed momentarily
- FCoE network will be dropped unless network interface is restarted or server is rebooted