### PR TITLE
ASM-5722 Switchport/Portmode bugfix

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -60,6 +60,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
         existing_config=(transport.command('show config') || '').split("\n").reverse
         updated_config = existing_config.find_all {|x| x.match(/dcb|switchport|spanning|vlan/)}
         updated_config.each do |remove_command|
+          remove_command = remove_command.split(" ")[0..-2].join(" ") if remove_command.match /vlan untagged/
           transport.command("no #{remove_command}")
         end
         transport.command('portmode hybrid')


### PR DESCRIPTION
Fixed the removal of untagged vlans.
Untagged vlans need to be removed using `# no vlan untagged` instead
of `# no vlan untagged 42` Without the vlan being removed we cannot
change the port mode/type