### PR TITLE
ASM-7082: supports vlan tagging and untagging when switch is in full-switch

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -73,7 +73,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
 
     ifprop(base, :vlan_tagged) do
       match do |txt|
-        paramsarray=txt.match(/^T\s+(\S+)/)
+        paramsarray = txt.match(/^T\s+(\S+)/)
         if paramsarray.nil?
           param1 = :absent
         else
@@ -82,51 +82,68 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
         param1
       end
       add do |transport, value|
-        # Find the VLANS which are already configured
-        existing_config = transport.command("show config")
-        tagged_vlan = ( existing_config.scan(/vlan tagged\s+(.*?)$/m).flatten.first || '' )
-        vlans = tagged_vlan.split(",")
-        # This array will just contain all the currently tagged vlans individually, instead of being in a range such as 1-5
-        unranged_tagged_vlans = []
-        vlans.each_with_index do |vlan,index|
-          if vlan.include?('-')
-            vlan_range = vlan.split("-").flatten
-            vlan_value = (vlan_range[0]..vlan_range[1]).to_a
-            unranged_tagged_vlans.concat(vlan_value)
-          else
-            unranged_tagged_vlans.push(vlan)
-          end
-        end
-        requested_vlans = value.split(",").uniq.sort
-        Puppet.debug "Requested_vlans: #{requested_vlans}"
-
-        # Find VLANs that need to be skipped
-        missing_vlans = []
-        vlans_toadd = []
-        (1..4094).each do |vlan_id|
-          missing_vlans.push(vlan_id) if !requested_vlans.include?(vlan_id.to_s)
-        end
-
-        missing_vlans = missing_vlans.to_ranges.join(",").gsub(/\.\./,'-')
-        Puppet.debug "Missing VLAN Range: #{missing_vlans}"
-
-        if unranged_tagged_vlans == requested_vlans
-          Puppet.debug "No change"
+        if base.facts["system_type"].match(/PE-FN.*-IOM/) && base.facts["iom_mode"].eql?("full-switch")
+          transport.command("exit")
+          value.split(',').map{ |value|
+            transport.command("interface vlan #{value}")
+            existing_config = transport.command("show config")
+            existing_config.split("\n").map{|line|
+              (transport.command("no #{line}")) if line =~ /tagged TenGigabitEthernet\s\d+..*/
+              (transport.command("no #{line}")) if line =~ /untagged TenGigabitEthernet\s\d+..*/
+            }
+            transport.command("tagged #{scope_name}")
+            transport.command("tagged #{exit}")
+          }
+          transport.command("interface #{scope_name}")
         else
-          if unranged_tagged_vlans.empty?
-            vlans_toadd = value
-          else
-            requested_vlans.map { |x| vlans_toadd.push(x) if !unranged_tagged_vlans.include?(x) }
-            vlans_toadd = vlans_toadd.compact.flatten.uniq.to_ranges.join(",").gsub(/\.\./,'-')
+          # Find the VLANS which are already configured
+          existing_config = transport.command("show config")
+          tagged_vlan = ( existing_config.scan(/vlan tagged\s+(.*?)$/m).flatten.first || '' )
+          vlans = tagged_vlan.split(",")
+          # This array will just contain all the currently tagged vlans individually, instead of being in a range such as 1-5
+          unranged_tagged_vlans = []
+          vlans.each_with_index do |vlan,index|
+            if vlan.include?('-')
+              vlan_range = vlan.split("-").flatten
+              vlan_value = (vlan_range[0]..vlan_range[1]).to_a
+              unranged_tagged_vlans.concat(vlan_value)
+            else
+              unranged_tagged_vlans.push(vlan)
+            end
           end
+          requested_vlans = value.split(",").uniq.sort
+          Puppet.debug "Requested_vlans: #{requested_vlans}"
+
+          # Find VLANs that need to be skipped
+          missing_vlans = []
+          vlans_toadd = []
+          (1..4094).each do |vlan_id|
+            missing_vlans.push(vlan_id) if !requested_vlans.include?(vlan_id.to_s)
+          end
+
+          missing_vlans = missing_vlans.to_ranges.join(",").gsub(/\.\./,'-')
+          Puppet.debug "Missing VLAN Range: #{missing_vlans}"
+
+          if unranged_tagged_vlans == requested_vlans
+            Puppet.debug "No change"
+          else
+            if unranged_tagged_vlans.empty?
+              vlans_toadd = value
+            else
+              requested_vlans.map { |x| vlans_toadd.push(x) if !unranged_tagged_vlans.include?(x) }
+              vlans_toadd = vlans_toadd.compact.flatten.uniq.to_ranges.join(",").gsub(/\.\./,'-')
+            end
+          end
+
+          # Untag VLAN needs to be updated only if there is a overlap of untag VLAN with existing list of tag vlans
+          untag_vlan = ( existing_config.scan(/vlan untagged\s+(.*?)$/m).flatten.first || '' )
+
+          transport.command("no vlan untagged") if requested_vlans.include?(untag_vlan)
+
+          transport.command("no vlan tagged #{missing_vlans}") if !missing_vlans.nil?
+          transport.command("vlan tagged #{vlans_toadd}") if !vlans_toadd.nil?
+
         end
-
-        # Untag VLAN needs to be updated only if there is a overlap of untag VLAN with existing list of tag vlans
-        untag_vlan = ( existing_config.scan(/vlan untagged\s+(.*?)$/m).flatten.first || '' )
-        transport.command("no vlan untagged") if requested_vlans.include?(untag_vlan)
-
-        transport.command("no vlan tagged #{missing_vlans}") if !missing_vlans.nil?
-        transport.command("vlan tagged #{vlans_toadd}") if !vlans_toadd.nil?
       end
 
       remove { |*_| }
@@ -134,7 +151,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
 
     ifprop(base, :vlan_untagged) do
       match  do |txt|
-        paramsarray=txt.match(/^U\s+(\S+)/)
+        paramsarray = txt.match(/^U\s+(\S+)/)
         if paramsarray.nil?
           param1 = :absent
         else
@@ -142,11 +159,25 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
         end
         param1
       end
-
       add do |transport, value|
-        transport.command("no vlan untagged")
-        transport.command("no vlan tagged #{value}")
-        transport.command("vlan untagged #{value}")
+        if base.facts["system_type"].match(/PE-FN.*-IOM/) && base.facts["iom_mode"].eql?("full-switch")
+          transport.command("exit")
+          value.split(',').map{ |value|
+            transport.command("interface vlan #{value}")
+            existing_config = transport.command("show config")
+
+            existing_config.split("\n").map{|line|
+              (transport.command("no #{line}")) if line =~ /untagged TenGigabitEthernet\s\d+..*/
+            }
+            transport.command("untagged #{scope_name}")
+            transport.command("exit")
+          }
+          transport.command("interface #{scope_name}")
+        else
+          transport.command("no vlan untagged")
+          transport.command("no vlan tagged #{value}")
+          transport.command("vlan untagged #{value}")
+        end
       end
       remove do |transport, old_value|
         transport.command("no vlan untagged")
@@ -157,7 +188,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
 
     base.register_scoped :shutdown, general_scope do
       match do |txt|
-        paramsarray=txt.match(/^#{interfaceval} is up/)
+        paramsarray = txt.match(/^#{interfaceval} is up/)
         if paramsarray.nil?
           param1 = :true
         else
@@ -168,7 +199,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
 
       cmd "show interfaces #{interfaceval}"
       add do |transport, value|
-        if value==:true
+        if value ==:true
           transport.command("shutdown")
         else
           transport.command("no shutdown")

--- a/spec/unit/puppet_x/ioa_interface_spec.rb
+++ b/spec/unit/puppet_x/ioa_interface_spec.rb
@@ -4,6 +4,8 @@ require 'puppet_x/dell_iom/model'
 require 'puppet_x/dell_iom/model/ioa_interface'
 
 describe PuppetX::Dell_iom::Model::Ioa_interface do
+
+
   before do
     @config = File.read('spec/fixtures/ioa_config.out')
     @transport = double('transport').as_null_object
@@ -55,15 +57,20 @@ describe PuppetX::Dell_iom::Model::Ioa_interface do
     end
 
     describe 'when adding untagged vlans' do
+
+      let(:base){double('base').as_null_object}
+      let(:facts){{"system_type"=>"PE-FN-410S-IOM", "iom_mode" => "programable-mux"}}
+
       before do
         name = 'TenGigabitEthernet 0/3'
-        @interface = PuppetX::Dell_iom::Model::Ioa_interface.new(@transport, @config, {:name=>name})
+        @interface = PuppetX::Dell_iom::Model::Ioa_interface.new(@transport, facts, {:name=>name})
         @interface.retrieve
         @old_params = @interface.params_to_hash
         @new_params = @old_params.dup
       end
 
       it 'should set vlan to untagged' do
+          base.stub(:facts)
         @new_params[:vlan_untagged] = '15'
         @transport.should_receive(:command).with("vlan untagged 15")
         @interface.update(@old_params, @new_params)
@@ -82,12 +89,54 @@ describe PuppetX::Dell_iom::Model::Ioa_interface do
       end
     end
 
-    describe 'when adding tagged vlans' do
+    describe 'when adding vlans when switch is in full-switch mode' do
+      let(:facts){{"system_type"=>"PE-FN-410S-IOM", "iom_mode" => "full-switch"}}
       before do
         name = 'TenGigabitEthernet 0/3'
         config = "interface TenGigabitEthernet 0/3\n mtu 12000\n portmode hybrid\n switchport\n vlan tagged 20,23,28\n vlan untagged 18\n!"
         @transport.stub(:command).with("show config").and_return(config)
-        @interface = PuppetX::Dell_iom::Model::Ioa_interface.new(@transport, @config, {:name=>name})
+        @interface = PuppetX::Dell_iom::Model::Ioa_interface.new(@transport, facts, {:name=>name})
+        @interface.retrieve
+        @old_params = @interface.params_to_hash
+        @new_params = @old_params.dup
+      end
+
+      it "should add a tagged vlan to an interface when iom is in full-switch" do
+        @new_params[:vlan_tagged] = '15'
+        @transport.should_receive(:command).with("interface vlan 15")
+        @transport.should_receive(:command).with("show config").and_return("tagged TenGigabitEthernet 0/4\n \ntagged Port-channel 15")
+        @transport.should_receive(:command).with("no tagged TenGigabitEthernet 0/4" )
+        @transport.should_receive(:command).with("tagged TenGigabitEthernet 0/3" )
+        @interface.update(@old_params, @new_params)
+      end
+
+      it "should add untagged vlan to an interface when iom is in full switch" do
+        @new_params[:vlan_untagged] = '18'
+        @transport.should_receive(:command).with("interface vlan 18" )
+        @transport.should_receive(:command).with("show config").and_return("untagged TenGigabitEthernet 0/4\n \ntagged Port-channel 15")
+        @transport.should_receive(:command).with("no untagged TenGigabitEthernet 0/4" )
+        @transport.should_receive(:command).with("tagged TenGigabitEthernet 0/3" )
+        @interface.update(@old_params, @new_params)
+      end
+
+      it "should add multiple tagged vlans to an interface port" do
+        @new_params[:vlan_tagged] = "15,16,20"
+        @transport.should_receive(:command).with("interface vlan 15")
+        @transport.should_receive(:command).with("interface vlan 16")
+        @transport.should_receive(:command).with("interface vlan 20")
+        @transport.should_receive(:command).exactly(3).with("show config").and_return("tagged TenGigabitEthernet 0/4\n \ntagged Port-channel 15")
+        @interface.update(@old_params, @new_params)
+      end
+
+    end
+
+    describe 'when adding tagged vlans' do
+      let(:facts){{"system_type"=>"PE-FN-410S-IOM", "iom_mode" => "programable-mux"}}
+      before do
+        name = 'TenGigabitEthernet 0/3'
+        config = "interface TenGigabitEthernet 0/3\n mtu 12000\n portmode hybrid\n switchport\n vlan tagged 20,23,28\n vlan untagged 18\n!"
+        @transport.stub(:command).with("show config").and_return(config)
+        @interface = PuppetX::Dell_iom::Model::Ioa_interface.new(@transport, facts, {:name=>name})
         @interface.retrieve
         @old_params = @interface.params_to_hash
         @new_params = @old_params.dup


### PR DESCRIPTION
adds vlans when switch is in full-switch mode. previously it used force10 puppet module.This effects fnioa chassis configuration. this module will check the mode in the switch and configure vlan based on the mode.