### PR TITLE
ASM-7080:VLT will fail to configure from manufacturing setting for port 9 (Fc 0/9)

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
@@ -188,6 +188,14 @@ module PuppetX::Dell_iom::Model::Ioa_mode::Base
       add do |transport, value|
         interfaceports = JSON.parse(value)
         interfaceports.each do |i|
+          # checks if interface port is taken as fc as fc is not available in full-switch mode
+          # changes to Te if iom is in full-switch mode
+          if i.include?("Fc")
+            if base.facts["iom_mode"] == "full-switch"
+              i.gsub!('Fc', 'Te')
+            end
+          end
+
           i.gsub!('Fo', 'fortyGigE')
           i.gsub!('Te', 'Tengigabitethernet')
         end


### PR DESCRIPTION
When iom is reset to manufacturing settings interface port 9 and 10 are becoming forty_gig ports.In full-switch mode those ports becomes ten-gig ports. As chassis configuration is done in full-switch mode it fails to configure interface port. This change is not possible in asm deployer as facts are collected before iom configuration. with this PR it checks if iom is in full-switch then FC is substituted with Te.