### PR TITLE
ASM-7169 updated switch commands for FN-ioms in Full switch mode

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -92,16 +92,15 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
       add do |transport, value|
         if base.facts["system_type"].match(/PE-FN.*-IOM/) && base.facts["iom_mode"].eql?("full-switch")
           transport.command("exit")
-          value.split(',').map{ |value|
+          value.split(',').each do |value|
             transport.command("interface vlan #{value}")
             existing_config = transport.command("show config")
-            existing_config.split("\n").map{|line|
+            existing_config.split("\n").each do  |line|
               (transport.command("no #{line}")) if line =~ /tagged TenGigabitEthernet\s\d+..*/
               (transport.command("no #{line}")) if line =~ /untagged TenGigabitEthernet\s\d+..*/
-            }
+            end
             transport.command("tagged #{scope_name}")
-            transport.command("tagged #{exit}")
-          }
+          end
           transport.command("interface #{scope_name}")
         else
           # Find the VLANS which are already configured

--- a/spec/unit/puppet_x/ioa_interface_spec.rb
+++ b/spec/unit/puppet_x/ioa_interface_spec.rb
@@ -89,7 +89,7 @@ describe PuppetX::Dell_iom::Model::Ioa_interface do
       end
     end
 
-    describe 'when adding vlans when switch is in full-switch mode' do
+    describe 'when adding vlans & switch is in full-switch mode' do
       let(:facts){{"system_type"=>"PE-FN-410S-IOM", "iom_mode" => "full-switch"}}
       before do
         name = 'TenGigabitEthernet 0/3'
@@ -115,7 +115,9 @@ describe PuppetX::Dell_iom::Model::Ioa_interface do
         @transport.should_receive(:command).with("interface vlan 18" )
         @transport.should_receive(:command).with("show config").and_return("untagged TenGigabitEthernet 0/4\n \ntagged Port-channel 15")
         @transport.should_receive(:command).with("no untagged TenGigabitEthernet 0/4" )
-        @transport.should_receive(:command).with("tagged TenGigabitEthernet 0/3" )
+        @transport.should_receive(:command).with("untagged TenGigabitEthernet 0/3" )
+        @transport.should_receive(:command).with("exit")
+        @transport.should_receive(:command).with("interface TenGigabitEthernet 0/3" )
         @interface.update(@old_params, @new_params)
       end
 


### PR DESCRIPTION
Code changes will fix switch commands for FN-ioms in fullswitch mode,  which are failing during deployment of a service with switch configuration.  The code changes will resolve the issues 
