### PR TITLE
ASM-7311 Always send a 'no switchport' command with portchannel

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -203,6 +203,11 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
           end
         end
 
+        # ASM-7311 even if the port doesn't say it's in switchport mode,the
+        # 'no switchport' command is still necessary at times, otherwise the lacp
+        # commands will fail. Shouldn't hurt to just run the command everytime
+        transport.command("no switchport")
+
         existing_config = (transport.command("show config") || "").split("\n")
         # Remove existing port channel if one exists
         if existing_config.find {|line| line =~ /port-channel/}


### PR DESCRIPTION
For whatever reason, sometimes the port-channel-protocol command on
on a port will fail until 'no switchport' command is given. Since we
are already attempting to turn switchport mode off if it's enabled
anyway, we just ensure the command is run everytime, regardless of
whether it shows in the port's config.