### PR TITLE
ASM-7384 Added full support for vlan params on portchannel types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development, :test do
   gem 'rake'
   gem 'rspec'
   gem 'puppetlabs_spec_helper'
+  gem 'json_pure', '2.0.1'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion
   else

--- a/lib/puppet/provider/ioa_portchannel/dell_iom.rb
+++ b/lib/puppet/provider/ioa_portchannel/dell_iom.rb
@@ -1,0 +1,17 @@
+require 'puppet/provider/dell_iom'
+
+Puppet::Type.type(:ioa_portchannel).provide :dell_iom, :parent => Puppet::Provider::Dell_iom do
+
+  desc "Dell IOM switch provider for port-channel configuration."
+
+  mk_resource_methods
+
+  def self.get_current(name)
+    transport.switch.ioa_portchannel(name).params_to_hash
+  end
+
+  def flush
+    transport.switch.ioa_portchannel(name).update(former_properties, properties)
+    super
+  end
+end

--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -245,8 +245,5 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
         transport.command("no port-channel-protocol lacp")
       end
     end
-
-
-
   end
 end

--- a/lib/puppet_x/dell_iom/model/ioa_portchannel.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_portchannel.rb
@@ -1,0 +1,12 @@
+#This class has the responsibility of creating and deleting the portchannel resource
+require 'puppet_x/force10/model/portchannel'
+
+class PuppetX::Dell_iom::Model::Ioa_portchannel < PuppetX::Force10::Model::Portchannel
+  def mod_path_base
+    'puppet_x/dell_iom/model/ioa_portchannel'
+  end
+
+  def mod_const_base
+    PuppetX::Dell_iom::Model::Ioa_portchannel
+  end
+end

--- a/lib/puppet_x/dell_iom/model/ioa_portchannel/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_portchannel/base.rb
@@ -1,0 +1,95 @@
+require 'puppet_x/force10/model/portchannel/base'
+require 'puppet_x/force10/model/portchannel/generic'
+
+module PuppetX::Dell_iom::Model::Ioa_portchannel::Base
+  extend PuppetX::Force10::Model::Portchannel::Generic
+
+  def self.register(base)
+    portchannel_scope = /^(L*\s*(\d+)\s+(.*))/
+
+    register_main_params(base)
+
+    base.register_scoped :tagged_vlan, portchannel_scope do
+      cmd "show interface port-channel %s" % base.name
+      match do |txt|
+        params_array=txt.match(/^T\s+(\S+)/)
+        if params_array.nil?
+          param = :absent
+        else
+          param = params_array[1]
+        end
+        param
+      end
+      add do |transport, value|
+        # Find the VLANS which are already configured
+        existing_config = transport.command("show config")
+        tagged_vlan = ( existing_config.scan(/vlan tagged\s+(.*?)$/m).flatten.first || "" )
+        vlans = tagged_vlan.split(",")
+        # This array will just contain all the currently tagged vlans individually, instead of being in a range such as 1-5
+        unranged_tagged_vlans = []
+        vlans.each do |vlan|
+          if vlan.include?("-")
+            vlan_range = vlan.split("-").flatten
+            vlan_value = (vlan_range[0]..vlan_range[1]).to_a
+            unranged_tagged_vlans.concat(vlan_value)
+          else
+            unranged_tagged_vlans.push(vlan)
+          end
+        end
+        requested_vlans = value.split(",").uniq.sort
+
+        # Find VLANs that need to be skipped
+        missing_vlans = []
+        vlans_to_add = []
+        (1..4094).each do |vlan_id|
+          missing_vlans.push(vlan_id) unless requested_vlans.include?(vlan_id.to_s)
+        end
+
+        missing_vlans = missing_vlans.to_ranges.join(",").gsub(/\.\./,"-")
+        Puppet.debug "Missing VLAN Range: #{missing_vlans}"
+
+        if unranged_tagged_vlans == requested_vlans
+          Puppet.debug "No change to tagged_vlans"
+        else
+          if unranged_tagged_vlans.empty?
+            vlans_to_add = value
+          else
+            requested_vlans.map { |x| vlans_to_add.push(x) if !unranged_tagged_vlans.include?(x) }
+            vlans_to_add = vlans_to_add.compact.flatten.uniq.to_ranges.join(",").gsub(/\.\./,'-')
+          end
+        end
+
+        # Untag VLAN needs to be updated only if there is a overlap of untag VLAN with existing list of tag vlans
+        untag_vlan = ( existing_config.scan(/vlan untagged\s+(.*?)$/m).flatten.first || "" )
+        transport.command("no vlan untagged") if requested_vlans.include?(untag_vlan)
+
+        transport.command("no vlan tagged #{missing_vlans}") if !missing_vlans.nil?
+        transport.command("vlan tagged #{vlans_to_add}") if !vlans_to_add.nil?
+      end
+
+      remove { |*_| }
+    end
+
+    base.register_scoped :untagged_vlan, portchannel_scope do
+      cmd "show interface port-channel %s" % base.name
+      match  do |txt|
+        params_array=txt.match(/^U\s+(\S+)/)
+        if params_array.nil?
+          param = :absent
+        else
+          param = params_array[1]
+        end
+        param
+      end
+
+      add do |transport, value|
+        transport.command("no vlan untagged")
+        transport.command("no vlan tagged #{value}")
+        transport.command("vlan untagged #{value}")
+      end
+      remove do |transport, old_value|
+        transport.command("no vlan untagged")
+      end
+    end
+  end
+end

--- a/lib/puppet_x/dell_iom/model/switch.rb
+++ b/lib/puppet_x/dell_iom/model/switch.rb
@@ -11,6 +11,7 @@ require 'puppet_x/force10/model/portchannel'
 require 'puppet_x/force10/model/quadmode'
 require 'puppet_x/dell_iom/model'
 require 'puppet_x/dell_iom/model/ioa_interface'
+require 'puppet_x/dell_iom/model/ioa_portchannel'
 require 'puppet_x/dell_iom/model/ioa_mode'
 require 'puppet_x/dell_iom/model/ioa_autolag'
 
@@ -78,7 +79,8 @@ class PuppetX::Dell_iom::Model::Switch < PuppetX::Force10::Model::Base
   [
     :ioa_interface,
     :ioa_mode,
-    :ioa_autolag
+    :ioa_autolag,
+    :ioa_portchannel
   ].each do |key|
     define_method key.to_s do |name|
       #grp = params[key].value.find { |resourcegrp| resourcegrp.name == name }


### PR DESCRIPTION
IOAs have a different way of configuring VLANs for portchannels.  This
code splits IOA portchannel configuration from the normal
force10_portchannel. They both extend a new generic portchannel module,
and have their own separate configuration for VLANs (which is the only
main difference)