### PR TITLE
ASM-7416:Increased waiting time for switch-mode

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
@@ -71,7 +71,7 @@ module PuppetX::Dell_iom::Model::Ioa_mode::Base
             # Close connection and call connect method to restore the connection
             transport.close
             # Sleeping for a minute
-            (1..5).each do |retry_count|
+            (1..9).each do |retry_count|
               sleep(60)
               begin
                 transport.connect


### PR DESCRIPTION
previously switch fails to reconnect after changing the switch mode which is a Intermittent issue.This happens switch not completely changed its mode.

This PR increases the waiting time to re-connect after changing the switch mode.