### PR TITLE
ASM-7540 Switchport should be configured after portmode

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_interface/base.rb
@@ -32,6 +32,7 @@ module PuppetX::Dell_iom::Model::Ioa_interface::Base
     end
 
     ifprop(base, :switchport) do
+      after :portmode
       match do |switchporttxt|
         unless switchporttxt.nil?
           switchporttxt.downcase.include? "vlan membership"


### PR DESCRIPTION
This caused errors in switchport mode and vlans not propertly being set,
due to due to portmode needing to be configured before, as well as some
code in portmode param that was removing existing configuration under
the assumption that portmode would be set first