### PR TITLE
ASM-8073:Handles nil class if there are no existing port_channels

### DIFF
--- a/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_mode/base.rb
@@ -257,18 +257,20 @@ module PuppetX::Dell_iom::Model::Ioa_mode::Base
     existingportschannels = PuppetX::Dell_iom::Model::Ioa_mode::Base.get_existing_port_channels(transport)
     transport.command('enable')
     transport.command('configure terminal', :prompt => /\(conf\)#\z/n)
-    existingportschannels.each do |portchannel|
-      transport.command("int port-channel #{portchannel}")
-      cmdout=transport.command('show config')
-      portconfig=cmdout.split("\n")
-      portconfig.each do |line|
-        if line.include? 'channel-member'
-          transport.command("no #{line}")
-          transport.command('shutdown')
+    if existingportschannels
+      existingportschannels.each do |portchannel|
+        transport.command("int port-channel #{portchannel}")
+        cmdout=transport.command('show config')
+        portconfig=cmdout.split("\n")
+        portconfig.each do |line|
+          if line.include? 'channel-member'
+            transport.command("no #{line}")
+            transport.command('shutdown')
+          end
         end
+        transport.command('exit')
+        transport.command("no interface port-channel #{portchannel}")
       end
-      transport.command('exit')
-      transport.command("no interface port-channel #{portchannel}")
     end
     transport.command('end')
   end

--- a/spec/unit/puppet_x/ioa_mode_spec.rb
+++ b/spec/unit/puppet_x/ioa_mode_spec.rb
@@ -104,6 +104,22 @@ describe PuppetX::Dell_iom::Model::Ioa_mode do
     PuppetX::Dell_iom::Model::Ioa_mode::Base.remove_vlt_uplinks(@transport)
   end
 
+  it "should also handle uplinks if no port-channel was found" do
+    facts = {'ioa_ethernet_mode' => 'mock', 'iom_mode' => 'standalone', 'product_name' => 'iomock-2100'}
+    model.should_receive(:remove_vlt_domain_setting_uplink).with(@transport)
+    model.should_receive(:get_existing_port_channels).with(@transport).and_return(nil)
+    @transport.should_receive(:command).ordered.with('enable')
+    @transport.should_receive(:command).ordered.with('configure terminal', :prompt => /\(conf\)#\z/n)
+    @transport.should_not_receive(:command).with('int port-channel 128 ')
+    @transport.should_not_receive(:command).with('show config')
+    @transport.should_not_receive(:command).with('no channel-member Te0/44')
+    @transport.should_not_receive(:command).with('shutdown')
+    @transport.should_not_receive(:command).with('exit')
+    @transport.should_not_receive(:command).with('no interface port-channel 128 ')
+    @transport.should_receive(:command).ordered.with('end')
+    PuppetX::Dell_iom::Model::Ioa_mode::Base.remove_vlt_uplinks(@transport)
+  end
+
   it 'should configure vlt settings' do
     facts = {'ioa_ethernet_mode' => 'mock', 'iom_mode' => 'standalone', 'product_name' => 'iomock-2100'}
     interface_port=["Tengigabitethernet 0/33", "Tengigabitethernet 0/37"]


### PR DESCRIPTION
Previously puppet would throw nil class exception when trying to remove
port-channels when there are no existing port-channels.

This PR will handle that situation and avoids raising exception.