### PR TITLE
ASM-8056: Configures MTU for vlt interface ports

### DIFF
--- a/lib/puppet/type/ioa_mode.rb
+++ b/lib/puppet/type/ioa_mode.rb
@@ -35,10 +35,14 @@ Puppet::Type.newtype(:ioa_mode) do
     newvalues(:true,:false)
   end
 
+  newproperty(:mtu) do
+    desc 'mtu for VLT port-channel and interface port'
+  end
+
   newproperty(:port_channel) do
     desc 'for vlt peer-port channel'
     validate do |value|
-      return if value == :absent || value.nil?
+       return if value == :absent || value.nil?
     end
   end
 
@@ -59,7 +63,7 @@ Puppet::Type.newtype(:ioa_mode) do
   newproperty(:interface) do
     desc 'interface ports to be assigned to the port channel'
     validate do |value|
-      return if value == :absent || value.empty?
+    return if value == :absent || value.empty?
     end
   end
 

--- a/lib/puppet_x/dell_iom/model/ioa_mode.rb
+++ b/lib/puppet_x/dell_iom/model/ioa_mode.rb
@@ -5,7 +5,7 @@ require 'puppet_x/dell_iom/model'
 class PuppetX::Dell_iom::Model::Ioa_mode < PuppetX::Force10::Model::Base
 
   attr_reader :params, :name
-  attr_accessor :port, :destination_ip, :device_id, :interfaceport
+  attr_accessor :port, :destination_ip, :device_id, :interfaceport, :mtu
 
   def initialize(transport, facts, options)
     super(transport, facts)

--- a/spec/unit/puppet_x/ioa_mode_spec.rb
+++ b/spec/unit/puppet_x/ioa_mode_spec.rb
@@ -71,8 +71,9 @@ describe PuppetX::Dell_iom::Model::Ioa_mode do
     @transport.should_receive(:command).once.ordered.with('channel-member Tengigabitethernet 0/33')
     @transport.should_receive(:command).once.ordered.with('channel-member Tengigabitethernet 0/37')
     @transport.should_receive(:command).once.ordered.with('no shutdown')
+    @transport.should_receive(:command).once.ordered.with('mtu 9216')
     @transport.should_receive(:command).once.ordered.with('end')
-    PuppetX::Dell_iom::Model::Ioa_mode::Base.configureportchannel(@transport, port_channel, interface_port)
+    PuppetX::Dell_iom::Model::Ioa_mode::Base.configureportchannel(@transport, port_channel, interface_port, "9216")
   end
 
   it 'configure vlt domain ' do
@@ -128,9 +129,9 @@ describe PuppetX::Dell_iom::Model::Ioa_mode do
     destination_ip = "172.17.2.223"
     device_id = "0"
     model.should_receive(:remove_vlt_uplinks).with(@transport)
-    model.should_receive(:configureportchannel).with(@transport, port, interface_port)
+    model.should_receive(:configureportchannel).with(@transport, port, interface_port, "9216")
     model.should_receive(:configure_vltdomain).with(@transport, vltdomain)
-    PuppetX::Dell_iom::Model::Ioa_mode::Base.configure_vlt_setting(@transport, interface_port, destination_ip, device_id, port)
+    PuppetX::Dell_iom::Model::Ioa_mode::Base.configure_vlt_setting(@transport, interface_port, destination_ip, device_id, port, "9216")
   end
 
   it 'should list the existing port channels' do


### PR DESCRIPTION
Previously MTU is not set for the vlt interface ports.

This PR will configure MTU while configuring interface with MTU 9216