### PR TITLE
ASM-9659 Fix non-disruptive update to skip network configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gem 'dell-force10', :git => 'https://github.com/dell-asm/dell-force10.git'
 
 group :development, :test do
   gem 'rake'
-  gem 'rspec'
-  gem 'puppetlabs_spec_helper'
+  gem 'rspec', '~>3.4.0', :require => false
+  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
   gem 'json_pure', '2.0.1'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion

--- a/lib/puppet/type/ioa_interface.rb
+++ b/lib/puppet/type/ioa_interface.rb
@@ -87,5 +87,10 @@ Puppet::Type.newtype(:ioa_interface) do
     end
   end
 
+  newproperty(:inclusive_vlans) do
+    desc "Flag to indicate if existing vlans needs to be included"
+    newvalues(:true, :false)
+  end
+
 end
 


### PR DESCRIPTION
Added support for new property "inclusive_vlans". When value if set to true then all existing vlans on the interface is retained and provided vlan is added to the list.